### PR TITLE
feat: refresh interface styling with qss theme

### DIFF
--- a/src/about_dialog.py
+++ b/src/about_dialog.py
@@ -114,7 +114,7 @@ class AboutDialog(QDialog):
         app_name_font.setPointSize(24)
         app_name_font.setBold(True)
         app_name.setFont(app_name_font)
-        app_name.setStyleSheet("color: #2c3e50; margin: 10px 0;")
+        app_name.setObjectName("aboutAppName")
         title_layout.addWidget(app_name)
 
         # 副标题
@@ -123,13 +123,13 @@ class AboutDialog(QDialog):
         subtitle_font = QFont()
         subtitle_font.setPointSize(14)
         subtitle.setFont(subtitle_font)
-        subtitle.setStyleSheet("color: #7f8c8d; margin-bottom: 5px;")
+        subtitle.setObjectName("aboutSubtitle")
         title_layout.addWidget(subtitle)
 
         # 版本信息
         version = QLabel(f"版本 {self.app_info.get('version', '1.0.0')}")
         version.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        version.setStyleSheet("color: #95a5a6; font-size: 12px;")
+        version.setObjectName("aboutVersion")
         title_layout.addWidget(version)
 
         parent_layout.addLayout(title_layout)
@@ -137,18 +137,18 @@ class AboutDialog(QDialog):
     def create_description_section(self, parent_layout):
         """创建软件描述区域"""
         desc_label = QLabel("软件描述")
-        desc_label.setStyleSheet("font-weight: bold; font-size: 14px; color: #2c3e50; margin-bottom: 5px;")
+        desc_label.setProperty("variant", "sectionTitle")
         parent_layout.addWidget(desc_label)
 
         description = QLabel("一款高效、易用的桌面应用程序，用于对图片进行文字描述标注。")
         description.setWordWrap(True)
-        description.setStyleSheet("color: #34495e; line-height: 1.4; margin-bottom: 10px;")
+        description.setProperty("variant", "bodyText")
         parent_layout.addWidget(description)
 
     def create_features_section(self, parent_layout):
         """创建功能特点区域"""
         features_label = QLabel("功能特点")
-        features_label.setStyleSheet("font-weight: bold; font-size: 14px; color: #2c3e50; margin-bottom: 5px;")
+        features_label.setProperty("variant", "sectionTitle")
         parent_layout.addWidget(features_label)
 
         features_text = """• 智能图片管理：使用SHA256哈希值确保图片与标签的准确对应
@@ -159,13 +159,13 @@ class AboutDialog(QDialog):
 
         features = QLabel(features_text)
         features.setWordWrap(True)
-        features.setStyleSheet("color: #34495e; line-height: 1.6; margin-bottom: 10px;")
+        features.setProperty("variant", "bodyText")
         parent_layout.addWidget(features)
 
     def create_developer_section(self, parent_layout):
         """创建开发者信息区域"""
         dev_label = QLabel("开发者信息")
-        dev_label.setStyleSheet("font-weight: bold; font-size: 14px; color: #2c3e50; margin-bottom: 5px;")
+        dev_label.setProperty("variant", "sectionTitle")
         parent_layout.addWidget(dev_label)
 
         # 开发者信息布局
@@ -174,15 +174,17 @@ class AboutDialog(QDialog):
         # GitHub项目地址
         project_layout = QHBoxLayout()
         project_label = QLabel("项目地址：")
-        project_label.setStyleSheet("color: #34495e;")
+        project_label.setProperty("variant", "mutedLabel")
         project_layout.addWidget(project_label)
 
         github_url = self.app_info.get(
             "github", "https://github.com/xinyang20/LabelFlow"
         )
-        project_link = QLabel(f'<a href="{github_url}">{github_url}</a>')
+        project_link = QLabel(
+            f'<a href="{github_url}" style="color: inherit; text-decoration: none;">{github_url}</a>'
+        )
         project_link.setOpenExternalLinks(True)
-        project_link.setStyleSheet("color: #3498db;")
+        project_link.setProperty("variant", "link")
         project_layout.addWidget(project_link)
         project_layout.addStretch()
 
@@ -191,14 +193,16 @@ class AboutDialog(QDialog):
         # 开发者GitHub
         dev_github_layout = QHBoxLayout()
         dev_github_label = QLabel("开发者：")
-        dev_github_label.setStyleSheet("color: #34495e;")
+        dev_github_label.setProperty("variant", "mutedLabel")
         dev_github_layout.addWidget(dev_github_label)
 
         author = self.app_info.get('author', 'xinyang20')
         author_github_url = f"https://github.com/{author}/"
-        dev_github_link = QLabel(f'<a href="{author_github_url}">{author}</a>')
+        dev_github_link = QLabel(
+            f'<a href="{author_github_url}" style="color: inherit; text-decoration: none;">{author}</a>'
+        )
         dev_github_link.setOpenExternalLinks(True)
-        dev_github_link.setStyleSheet("color: #3498db;")
+        dev_github_link.setProperty("variant", "link")
         dev_github_layout.addWidget(dev_github_link)
         dev_github_layout.addStretch()
 
@@ -207,13 +211,15 @@ class AboutDialog(QDialog):
         # 联系邮箱
         email_layout = QHBoxLayout()
         email_label = QLabel("联系邮箱：")
-        email_label.setStyleSheet("color: #34495e;")
+        email_label.setProperty("variant", "mutedLabel")
         email_layout.addWidget(email_label)
 
         email = self.app_info.get('email', 'gaoxinyang317@gmail.com')
-        email_link = QLabel(f'<a href="mailto:{email}">{email}</a>')
+        email_link = QLabel(
+            f'<a href="mailto:{email}" style="color: inherit; text-decoration: none;">{email}</a>'
+        )
         email_link.setOpenExternalLinks(True)
-        email_link.setStyleSheet("color: #3498db;")
+        email_link.setProperty("variant", "link")
         email_layout.addWidget(email_link)
         email_layout.addStretch()
 
@@ -228,43 +234,12 @@ class AboutDialog(QDialog):
 
         # 访问GitHub按钮
         github_button = QPushButton("访问GitHub项目")
-        github_button.setStyleSheet("""
-            QPushButton {
-                background-color: #3498db;
-                color: white;
-                border: none;
-                padding: 8px 16px;
-                border-radius: 4px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #2980b9;
-            }
-            QPushButton:pressed {
-                background-color: #21618c;
-            }
-        """)
         github_button.clicked.connect(self.open_github)
         button_layout.addWidget(github_button)
 
         # 关闭按钮
         close_button = QPushButton("关闭")
-        close_button.setStyleSheet("""
-            QPushButton {
-                background-color: #95a5a6;
-                color: white;
-                border: none;
-                padding: 8px 16px;
-                border-radius: 4px;
-                font-weight: bold;
-            }
-            QPushButton:hover {
-                background-color: #7f8c8d;
-            }
-            QPushButton:pressed {
-                background-color: #6c7b7d;
-            }
-        """)
+        close_button.setProperty("buttonRole", "secondary")
         close_button.clicked.connect(self.close)
         button_layout.addWidget(close_button)
 

--- a/src/app_controller.py
+++ b/src/app_controller.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-LabelFlow - 快捷图片标注工具 - 应用控制器
-"""
+"""LabelFlow - 快捷图片标注工具 - 应用控制器"""
+
+import os
+import sys
 
 from PyQt6.QtCore import QObject, QTimer
 from PyQt6.QtWidgets import QApplication, QMessageBox
@@ -25,6 +26,7 @@ class AppController(QObject):
 
         self.setup_connections()
         self.setup_auto_save()
+        self.apply_stylesheet()
         
     def setup_connections(self):
         """设置信号连接"""
@@ -54,7 +56,35 @@ class AppController(QObject):
         """设置自动保存"""
         self.auto_save_timer.timeout.connect(self.auto_save_annotation)
         self.auto_save_timer.setSingleShot(True)
-        
+
+    def apply_stylesheet(self):
+        """加载并应用全局样式表"""
+        app = QApplication.instance()
+        if app is None:
+            return
+
+        try:
+            QApplication.setStyle("Fusion")
+
+            base_dir = getattr(sys, "_MEIPASS", None)
+            if base_dir is None:
+                base_dir = os.path.dirname(os.path.abspath(__file__))
+
+            style_path = os.path.join(base_dir, "styles", "app.qss")
+
+            if not os.path.exists(style_path):
+                fallback_path = os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), "styles", "app.qss"
+                )
+                if os.path.exists(fallback_path):
+                    style_path = fallback_path
+
+            if os.path.exists(style_path):
+                with open(style_path, "r", encoding="utf-8") as style_file:
+                    app.setStyleSheet(style_file.read())
+        except Exception as exc:
+            print(f"加载样式表失败: {exc}")
+
     def show(self):
         """显示主窗口"""
         self.main_window.show()

--- a/src/styles/app.qss
+++ b/src/styles/app.qss
@@ -1,0 +1,388 @@
+/* LabelFlow Modern Theme */
+
+QWidget {
+    font-family: "Segoe UI", "Microsoft YaHei", "PingFang SC", "Helvetica Neue", sans-serif;
+    font-size: 13px;
+    color: #1f2933;
+    background-color: #f5f7fb;
+}
+
+QMainWindow, QDialog {
+    background-color: #f5f7fb;
+}
+
+QMenuBar {
+    background-color: #ffffff;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+QMenuBar::item {
+    padding: 6px 12px;
+    margin: 2px;
+    border-radius: 6px;
+}
+
+QMenuBar::item:selected {
+    background-color: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+}
+
+QMenu {
+    background-color: #ffffff;
+    border: 1px solid #d7dce5;
+    padding: 6px 0;
+}
+
+QMenu::item {
+    padding: 6px 18px;
+    border-radius: 0;
+}
+
+QMenu::item:selected {
+    background-color: rgba(37, 99, 235, 0.12);
+    color: #1d4ed8;
+}
+
+QStatusBar {
+    background-color: #ffffff;
+    border-top: 1px solid #e2e8f0;
+}
+
+QStatusBar::item {
+    border: none;
+}
+
+QLabel#versionLabel {
+    color: #64748b;
+    font-size: 12px;
+    margin-right: 12px;
+}
+
+QLabel#statusSeparator {
+    color: #cbd5f5;
+    margin: 0 8px;
+}
+
+/* Information cards */
+QFrame#infoCard,
+QFrame#descriptionCard,
+QFrame#labelCard,
+QFrame#fileListCard,
+QFrame#zoomControlCard {
+    background-color: #ffffff;
+    border: 1px solid #d7dce5;
+    border-radius: 12px;
+    padding: 12px;
+}
+
+QFrame#infoCard QLabel {
+    font-size: 13px;
+}
+
+QLabel#infoFilenameLabel {
+    font-weight: 600;
+}
+
+QLabel#hashValueLabel {
+    font-family: "JetBrains Mono", "Cascadia Code", "Consolas", monospace;
+    color: #475569;
+}
+
+QLabel#progressInfoLabel {
+    color: #334155;
+}
+
+QLabel#fileListTitle {
+    font-weight: 600;
+    color: #1f2937;
+    margin-bottom: 6px;
+}
+
+QListWidget {
+    background-color: #ffffff;
+    border: 1px solid #d7dce5;
+    border-radius: 10px;
+    padding: 4px;
+}
+
+QListWidget::item {
+    padding: 6px 8px;
+    border-radius: 6px;
+}
+
+QListWidget::item:hover {
+    background-color: rgba(37, 99, 235, 0.08);
+}
+
+QListWidget::item:selected {
+    background-color: rgba(37, 99, 235, 0.18);
+    color: #1e3a8a;
+}
+
+/* Buttons */
+QPushButton {
+    background-color: #2563eb;
+    color: #ffffff;
+    border: none;
+    border-radius: 8px;
+    padding: 6px 14px;
+    font-weight: 500;
+}
+
+QPushButton:hover {
+    background-color: #1d4ed8;
+}
+
+QPushButton:pressed {
+    background-color: #1e40af;
+}
+
+QPushButton:disabled {
+    background-color: #d0d8ec;
+    color: #9aa5c2;
+}
+
+QPushButton[buttonRole="secondary"] {
+    background-color: #ffffff;
+    color: #1f2933;
+    border: 1px solid #cbd5f5;
+}
+
+QPushButton[buttonRole="secondary"]:hover {
+    background-color: rgba(37, 99, 235, 0.08);
+    border: 1px solid #2563eb;
+}
+
+QPushButton[buttonRole="secondary"]:pressed {
+    background-color: rgba(37, 99, 235, 0.16);
+}
+
+/* Inputs */
+QLineEdit,
+QTextEdit,
+QPlainTextEdit,
+QSpinBox,
+QDoubleSpinBox,
+QComboBox,
+QTreeWidget,
+QTableWidget,
+QTableView {
+    background-color: #ffffff;
+    border: 1px solid #d7dce5;
+    border-radius: 8px;
+    padding: 6px 8px;
+}
+
+QTextEdit {
+    padding: 8px;
+}
+
+QLineEdit:focus,
+QTextEdit:focus,
+QPlainTextEdit:focus,
+QComboBox:focus,
+QSpinBox:focus,
+QDoubleSpinBox:focus {
+    border: 1px solid #2563eb;
+    background-color: #ffffff;
+}
+
+QComboBox::drop-down {
+    border: none;
+    width: 24px;
+}
+
+QComboBox::down-arrow {
+    image: none;
+}
+
+/* Checkboxes */
+QCheckBox {
+    spacing: 8px;
+}
+
+QCheckBox::indicator {
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    border: 1px solid #cbd5f5;
+    background-color: #ffffff;
+}
+
+QCheckBox::indicator:hover {
+    border: 1px solid #2563eb;
+}
+
+QCheckBox::indicator:checked {
+    background-color: #2563eb;
+    border: 1px solid #2563eb;
+    image: url(:/qt-project.org/styles/commonstyle/images/check.png);
+}
+
+/* Scroll areas */
+QScrollArea {
+    border: none;
+    background: transparent;
+}
+
+QScrollArea > QWidget > QWidget {
+    background: transparent;
+}
+
+/* Scroll bars */
+QScrollBar:vertical {
+    background: transparent;
+    width: 10px;
+    margin: 4px 0 4px 0;
+}
+
+QScrollBar::handle:vertical {
+    background: rgba(15, 23, 42, 0.25);
+    min-height: 30px;
+    border-radius: 5px;
+}
+
+QScrollBar::handle:vertical:hover {
+    background: rgba(37, 99, 235, 0.45);
+}
+
+QScrollBar::add-line:vertical,
+QScrollBar::sub-line:vertical,
+QScrollBar::add-page:vertical,
+QScrollBar::sub-page:vertical {
+    background: transparent;
+    height: 0;
+}
+
+QScrollBar:horizontal {
+    background: transparent;
+    height: 10px;
+    margin: 0 4px 0 4px;
+}
+
+QScrollBar::handle:horizontal {
+    background: rgba(15, 23, 42, 0.25);
+    min-width: 30px;
+    border-radius: 5px;
+}
+
+QScrollBar::handle:horizontal:hover {
+    background: rgba(37, 99, 235, 0.45);
+}
+
+QScrollBar::add-line:horizontal,
+QScrollBar::sub-line:horizontal,
+QScrollBar::add-page:horizontal,
+QScrollBar::sub-page:horizontal {
+    background: transparent;
+    width: 0;
+}
+
+/* Progress bar */
+QProgressBar {
+    background-color: #e2e8f0;
+    border: none;
+    border-radius: 6px;
+    height: 12px;
+}
+
+QProgressBar::chunk {
+    background-color: #2563eb;
+    border-radius: 6px;
+}
+
+/* Slider */
+QSlider::groove:horizontal {
+    background: #d7dce5;
+    height: 6px;
+    border-radius: 3px;
+}
+
+QSlider::handle:horizontal {
+    width: 16px;
+    margin: -6px 0;
+    border-radius: 8px;
+    background-color: #2563eb;
+}
+
+QSlider::handle:horizontal:hover {
+    background-color: #1d4ed8;
+}
+
+/* Splitter */
+QSplitter::handle {
+    background-color: #d7dce5;
+    border-radius: 4px;
+}
+
+QSplitter::handle:hover {
+    background-color: #9db3f7;
+}
+
+/* Tooltips */
+QToolTip {
+    color: #f8fafc;
+    background-color: #1f2937;
+    border: 1px solid #475569;
+    padding: 6px;
+    border-radius: 6px;
+}
+
+/* Image display */
+QLabel#imageDisplayLabel {
+    border: 2px dashed #a5b4fc;
+    border-radius: 16px;
+    background-color: rgba(37, 99, 235, 0.06);
+    color: #64748b;
+}
+
+QLabel#zoomValueLabel {
+    font-weight: 600;
+    color: #1f2933;
+}
+
+QLabel[variant="sectionTitle"] {
+    font-size: 15px;
+    font-weight: 600;
+    color: #1e293b;
+    margin-bottom: 6px;
+}
+
+QLabel[variant="bodyText"] {
+    color: #475569;
+    margin-bottom: 10px;
+}
+
+QLabel[variant="mutedLabel"] {
+    color: #64748b;
+}
+
+QLabel[variant="link"] {
+    color: #2563eb;
+    font-weight: 500;
+}
+
+QLabel[variant="link"]:hover {
+    color: #1d4ed8;
+}
+
+QLabel[variant="shortcutHint"] {
+    color: #94a3b8;
+    font-size: 11px;
+}
+
+QLabel#aboutAppName {
+    color: #0f172a;
+    margin: 12px 0 6px;
+}
+
+QLabel#aboutSubtitle {
+    color: #475569;
+    margin-bottom: 6px;
+}
+
+QLabel#aboutVersion {
+    color: #94a3b8;
+    font-size: 12px;
+}
+

--- a/src/ui_mainwindow.py
+++ b/src/ui_mainwindow.py
@@ -275,15 +275,9 @@ class MainWindow(QMainWindow):
         self.image_scroll.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.image_label = DraggableImageLabel()
+        self.image_label.setObjectName("imageDisplayLabel")
         self.image_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.image_label.setStyleSheet("""
-            QLabel {
-                border: 2px solid #cccccc;
-                background-color: #f5f5f5;
-                min-height: 400px;
-                min-width: 600px;
-            }
-        """)
+        self.image_label.setMinimumSize(600, 400)
         self.image_label.setText(tr("select_work_directory_to_start"))
         self.image_label.setScaledContents(False)  # 禁用自动缩放内容
 
@@ -306,31 +300,28 @@ class MainWindow(QMainWindow):
 
         # 文件信息区域 - 使用固定布局
         info_frame = QFrame()
+        info_frame.setObjectName("infoCard")
         info_frame.setFrameStyle(QFrame.Shape.Box)
-        info_frame.setStyleSheet("QFrame { border: 1px solid #cccccc; border-radius: 3px; padding: 8px; }")
         info_layout = QVBoxLayout(info_frame)
         info_layout.setContentsMargins(8, 8, 8, 8)
         info_layout.setSpacing(4)
 
-        # 统一字号样式
-        label_style = "font-size: 12px; font-weight: normal;"
-
         # 文件名显示
         self.filename_label = QLabel(f"{tr('filename')}: {tr('not_selected')}")
         self.filename_label.setWordWrap(True)
-        self.filename_label.setStyleSheet(label_style)
+        self.filename_label.setObjectName("infoFilenameLabel")
         info_layout.addWidget(self.filename_label)
 
         # 哈希值显示 - 预留两行空间
         self.hash_label = QLabel(f"SHA256: {tr('not_calculated')}")
         self.hash_label.setWordWrap(True)
-        self.hash_label.setStyleSheet(f"{label_style} font-family: monospace; min-height: 32px;")
+        self.hash_label.setObjectName("hashValueLabel")
         self.hash_label.setMinimumHeight(32)  # 确保有足够空间显示两行
         info_layout.addWidget(self.hash_label)
 
         # 进度显示
         self.progress_label = QLabel(f"{tr('progress')}: 0 / 0")
-        self.progress_label.setStyleSheet(label_style)
+        self.progress_label.setObjectName("progressInfoLabel")
         info_layout.addWidget(self.progress_label)
 
         control_layout.addWidget(info_frame)
@@ -365,14 +356,14 @@ class MainWindow(QMainWindow):
         """创建文件目录显示区域"""
         # 文件列表框架
         file_list_frame = QFrame()
+        file_list_frame.setObjectName("fileListCard")
         file_list_frame.setFrameStyle(QFrame.Shape.Box)
-        file_list_frame.setStyleSheet("QFrame { border: 1px solid #cccccc; border-radius: 3px; }")
         file_list_layout = QVBoxLayout(file_list_frame)
         file_list_layout.setContentsMargins(8, 8, 8, 8)
 
         # 标题
         file_list_label = QLabel("文件目录:")
-        file_list_label.setStyleSheet("font-size: 12px; font-weight: bold;")
+        file_list_label.setObjectName("fileListTitle")
         file_list_layout.addWidget(file_list_label)
 
         # 文件列表
@@ -390,12 +381,12 @@ class MainWindow(QMainWindow):
 
         # 版本号标签（左侧永久显示）
         self.version_label = QLabel(f"v{self.version}")
-        self.version_label.setStyleSheet("color: #666; font-size: 11px; margin-right: 10px;")
+        self.version_label.setObjectName("versionLabel")
         self.status_bar.addPermanentWidget(self.version_label)
 
         # 分隔符
         separator = QLabel("|")
-        separator.setStyleSheet("color: #ccc; margin: 0 5px;")
+        separator.setObjectName("statusSeparator")
         self.status_bar.addPermanentWidget(separator)
 
         # 进度条（右侧）
@@ -647,27 +638,19 @@ class MainWindow(QMainWindow):
         """创建标注区域 - 使用可拖拽的分割器"""
         # 创建垂直分割器用于标注区域
         self.annotation_splitter = QSplitter(Qt.Orientation.Vertical)
+        self.annotation_splitter.setObjectName("annotationSplitter")
         self.annotation_splitter.setChildrenCollapsible(False)  # 防止子部件被完全折叠
         self.annotation_splitter.setHandleWidth(8)  # 设置拖拽手柄宽度
-        self.annotation_splitter.setStyleSheet("""
-            QSplitter::handle {
-                background-color: #cccccc;
-                border: 1px solid #999999;
-                border-radius: 2px;
-            }
-            QSplitter::handle:hover {
-                background-color: #aaaaaa;
-            }
-        """)
 
         # 描述模式区域
         self.description_frame = QFrame()
+        self.description_frame.setObjectName("descriptionCard")
         self.description_frame.setFrameStyle(QFrame.Shape.Box)
-        self.description_frame.setStyleSheet("QFrame { border: 1px solid #cccccc; border-radius: 3px; }")
         desc_layout = QVBoxLayout(self.description_frame)
         desc_layout.setContentsMargins(8, 8, 8, 8)
 
         desc_label = QLabel(f"{tr('annotation_content')}:")
+        desc_label.setProperty("variant", "sectionTitle")
         desc_layout.addWidget(desc_label)
 
         self.annotation_text = QTextEdit()
@@ -680,14 +663,16 @@ class MainWindow(QMainWindow):
 
         # 标签模式区域
         self.label_frame = QFrame()
+        self.label_frame.setObjectName("labelCard")
         self.label_frame.setFrameStyle(QFrame.Shape.Box)
-        self.label_frame.setStyleSheet("QFrame { border: 1px solid #cccccc; border-radius: 3px; }")
         label_layout = QVBoxLayout(self.label_frame)
         label_layout.setContentsMargins(8, 8, 8, 8)
 
         # 新标签输入
         new_label_layout = QHBoxLayout()
-        new_label_layout.addWidget(QLabel(f"{tr('new_label')}:"))
+        new_label_label = QLabel(f"{tr('new_label')}:")
+        new_label_label.setProperty("variant", "mutedLabel")
+        new_label_layout.addWidget(new_label_label)
 
         self.new_label_input = QLineEdit()
         self.new_label_input.setPlaceholderText(tr("input_new_label"))
@@ -702,10 +687,12 @@ class MainWindow(QMainWindow):
 
         # 标签列表区域
         labels_label = QLabel(f"{tr('available_labels')}:")
+        labels_label.setProperty("variant", "sectionTitle")
         label_layout.addWidget(labels_label)
 
         # 创建滚动区域用于标签列表
         self.labels_scroll = QScrollArea()
+        self.labels_scroll.setObjectName("labelsScrollArea")
         self.labels_scroll.setWidgetResizable(True)
         self.labels_scroll.setMinimumHeight(100)  # 设置最小高度，移除最大高度限制
 
@@ -777,7 +764,7 @@ class MainWindow(QMainWindow):
             # 在标签模式和混合模式下添加快捷键提示
             if self.current_mode in ['label', 'mixed'] and i < 10:
                 shortcut_label = QLabel(f"Ctrl+{i}")
-                shortcut_label.setStyleSheet("color: #888888; font-size: 10px;")
+                shortcut_label.setProperty("variant", "shortcutHint")
                 shortcut_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
                 label_layout.addWidget(shortcut_label)
 
@@ -920,8 +907,8 @@ class MainWindow(QMainWindow):
     def create_zoom_controls(self, parent_layout):
         """创建缩放控制区域"""
         zoom_frame = QFrame()
+        zoom_frame.setObjectName("zoomControlCard")
         zoom_frame.setFrameStyle(QFrame.Shape.Box)
-        zoom_frame.setStyleSheet("QFrame { border: 1px solid #cccccc; border-radius: 3px; padding: 5px; }")
         zoom_layout = QHBoxLayout(zoom_frame)
         zoom_layout.setContentsMargins(5, 5, 5, 5)
 
@@ -931,6 +918,7 @@ class MainWindow(QMainWindow):
 
         # 缩小按钮
         zoom_out_btn = QPushButton("-")
+        zoom_out_btn.setProperty("buttonRole", "secondary")
         zoom_out_btn.setFixedSize(30, 25)
         zoom_out_btn.clicked.connect(self.zoom_out)
         zoom_layout.addWidget(zoom_out_btn)
@@ -946,6 +934,7 @@ class MainWindow(QMainWindow):
 
         # 放大按钮
         zoom_in_btn = QPushButton("+")
+        zoom_in_btn.setProperty("buttonRole", "secondary")
         zoom_in_btn.setFixedSize(30, 25)
         zoom_in_btn.clicked.connect(self.zoom_in)
         zoom_layout.addWidget(zoom_in_btn)
@@ -954,11 +943,12 @@ class MainWindow(QMainWindow):
         self.zoom_label = QLabel("100%")
         self.zoom_label.setFixedWidth(50)
         self.zoom_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
-        self.zoom_label.setStyleSheet("font-weight: bold; color: #2c3e50;")
+        self.zoom_label.setObjectName("zoomValueLabel")
         zoom_layout.addWidget(self.zoom_label)
 
         # 重置按钮
         reset_btn = QPushButton(tr("reset"))
+        reset_btn.setProperty("buttonRole", "secondary")
         reset_btn.setFixedSize(50, 25)
         reset_btn.clicked.connect(self.reset_zoom)
         zoom_layout.addWidget(reset_btn)


### PR DESCRIPTION
## Summary
- add a reusable QSS theme and apply it globally through the app controller for a more modern baseline look
- refactor main window and about dialog widgets to rely on the shared styling instead of hard-coded palettes while preserving layout and behavior

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c9071e4254832391a0463aa5408d27